### PR TITLE
Handle invalid URLs in settings connection tests

### DIFF
--- a/macollama/Views/Settings/SettingsView.swift
+++ b/macollama/Views/Settings/SettingsView.swift
@@ -370,9 +370,14 @@ struct SettingsView: View {
         connectionTestResult = nil
         
         Task {
+            guard let url = URL(string: serverAddress) else {
+                connectionTestResult = "l_connection_fail".localized
+                isTestingConnection = false
+                return
+            }
+
             do {
-                let url = URL(string: serverAddress)
-                var request = URLRequest(url: url!)
+                var request = URLRequest(url: url)
                 request.httpMethod = "GET"
                 request.timeoutInterval = 10.0
                 
@@ -398,9 +403,14 @@ struct SettingsView: View {
         lmStudioConnectionTestResult = nil
         
         Task {
+            guard let url = URL(string: lmStudioAddress) else {
+                lmStudioConnectionTestResult = "l_connection_fail".localized
+                isTestingLMStudioConnection = false
+                return
+            }
+
             do {
-                let url = URL(string: lmStudioAddress)
-                var request = URLRequest(url: url!)
+                var request = URLRequest(url: url)
                 request.httpMethod = "GET"
                 request.timeoutInterval = 10.0
                 


### PR DESCRIPTION
## Summary
- guard against invalid URLs in the Ollama and LM Studio connection tests
- report a localized failure immediately when the URL cannot be created

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df41e3ec50832581735751232604bc