### PR TITLE
Add reload callback to mac SettingsView

### DIFF
--- a/macollama/ContentView.swift
+++ b/macollama/ContentView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct ContentView: View {
-    static let shared = ContentView()
-    
     @State private var columnVisibility = NavigationSplitViewVisibility.automatic
     @State private var showingSettings = false
     @State private var models: [String] = []
@@ -55,7 +53,10 @@ struct ContentView: View {
             )
         }
         .sheet(isPresented: $showingSettings) {
-            SettingsView(isPresented: $showingSettings)
+            SettingsView(
+                isPresented: $showingSettings,
+                onReloadModels: { await loadModels() }
+            )
         }
         .task {
             await loadModels()

--- a/macollama/Views/Settings/SettingsView.swift
+++ b/macollama/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
+    private let onReloadModels: @Sendable () async -> Void
     @State private var serverAddress: String = UserDefaults.standard.string(forKey: "ollama_base_url") ?? "http://localhost:11434"
     @State private var lmStudioAddress: String = UserDefaults.standard.string(forKey: "lmStudioAddress") ?? "http://localhost:1234"
     @State private var claudeApiKey: String = UserDefaults.standard.string(forKey: "claudeApiKey") ?? ""
@@ -20,8 +21,12 @@ struct SettingsView: View {
     @State private var isTestingLMStudioConnection = false
     @State private var lmStudioConnectionTestResult: String?
     
-    init(isPresented: Binding<Bool> = .constant(false)) {
+    init(
+        isPresented: Binding<Bool> = .constant(false),
+        onReloadModels: @escaping @Sendable () async -> Void = {}
+    ) {
         self._isPresented = isPresented
+        self.onReloadModels = onReloadModels
     }
     
     var body: some View {
@@ -36,7 +41,7 @@ struct SettingsView: View {
                             }
                             .onChange(of: showOllama) {
                                 Task {
-                                    await ContentView.shared.loadModels()
+                                    await onReloadModels()
                                 }
                             }
                         }
@@ -85,7 +90,7 @@ struct SettingsView: View {
                             }
                             .onChange(of: showLMStudio) {
                                 Task {
-                                    await ContentView.shared.loadModels()
+                                    await onReloadModels()
                                 }
                             }
                         }
@@ -134,7 +139,7 @@ struct SettingsView: View {
                             }
                             .onChange(of: showClaude) {
                                 Task {
-                                    await ContentView.shared.loadModels()
+                                    await onReloadModels()
                                 }
                             }
                             .disabled(claudeApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -169,7 +174,7 @@ struct SettingsView: View {
                             }
                             .onChange(of: showOpenAI) {
                                 Task {
-                                    await ContentView.shared.loadModels()
+                                    await onReloadModels()
                                 }
                             }
                             .disabled(openaiApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -318,7 +323,7 @@ struct SettingsView: View {
                         saveSettings()
                         isPresented = false
                         Task {
-                            await ContentView.shared.loadModels()
+                            await onReloadModels()
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add a reload callback to macOS SettingsView so model lists refresh via the presenting ContentView
- update SettingsView to invoke the callback instead of the removed ContentView singleton
- pass the new closure from ContentView when showing the settings sheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df43d469a08325ad6fb1ffef31341e